### PR TITLE
FEATURE: Recursive workspace filter

### DIFF
--- a/Classes/EventLogFilter.php
+++ b/Classes/EventLogFilter.php
@@ -21,6 +21,7 @@ final class EventLogFilter
 
     private bool $recursively = false;
     private bool $includeBaseWorkspaces = false;
+    private bool $includeDerivedWorkspaces = false;
     private ?NodeAggregateIdentifier $nodeId = null;
     private ?WorkspaceName $workspaceName = null;
     private ?ContentStreamIdentifier $contentStreamId = null;
@@ -45,12 +46,16 @@ final class EventLogFilter
         return $newInstance;
     }
 
-    public function inWorkspace(WorkspaceName $workspaceName, bool $includeBaseWorkspaces = false): self
+    public function inWorkspace(WorkspaceName $workspaceName, bool $includeBaseWorkspaces = false, bool $includeDerivedWorkspaces = false): self
     {
         Assert::null($this->contentStreamId, 'content stream and workspace filter must not be combined');
+        if ($includeDerivedWorkspaces) {
+            Assert::false($includeBaseWorkspaces, 'includeBaseWorkspaces and includeDerivedWorkspaces must not be combined');
+        }
         $newInstance = clone $this;
         $newInstance->workspaceName = $workspaceName;
         $newInstance->includeBaseWorkspaces = $includeBaseWorkspaces;
+        $newInstance->includeDerivedWorkspaces = $includeDerivedWorkspaces;
         return $newInstance;
     }
 

--- a/Classes/EventLogFilter.php
+++ b/Classes/EventLogFilter.php
@@ -20,6 +20,7 @@ final class EventLogFilter
 {
 
     private bool $recursively = false;
+    private bool $includeBaseWorkspaces = false;
     private ?NodeAggregateIdentifier $nodeId = null;
     private ?WorkspaceName $workspaceName = null;
     private ?ContentStreamIdentifier $contentStreamId = null;
@@ -44,11 +45,12 @@ final class EventLogFilter
         return $newInstance;
     }
 
-    public function inWorkspace(WorkspaceName $workspaceName): self
+    public function inWorkspace(WorkspaceName $workspaceName, bool $includeBaseWorkspaces = false): self
     {
         Assert::null($this->contentStreamId, 'content stream and workspace filter must not be combined');
         $newInstance = clone $this;
         $newInstance->workspaceName = $workspaceName;
+        $newInstance->includeBaseWorkspaces = $includeBaseWorkspaces;
         return $newInstance;
     }
 

--- a/Classes/Projection/EventLogProjector.php
+++ b/Classes/Projection/EventLogProjector.php
@@ -46,12 +46,12 @@ final class EventLogProjector implements ProjectorInterface, BeforeInvokeInterfa
 
     public function whenRootWorkspaceWasCreated(RootWorkspaceWasCreated $event): void
     {
-        $this->repository->insertWorkspace($event->getWorkspaceName(), $event->getNewContentStreamIdentifier());
+        $this->repository->insertWorkspace($event->getWorkspaceName(), null, $event->getNewContentStreamIdentifier());
     }
 
     public function whenWorkspaceWasCreated(WorkspaceWasCreated $event): void
     {
-        $this->repository->insertWorkspace($event->getWorkspaceName(), $event->getNewContentStreamIdentifier());
+        $this->repository->insertWorkspace($event->getWorkspaceName(), $event->getBaseWorkspaceName(), $event->getNewContentStreamIdentifier());
     }
 
     public function whenWorkspaceWasRebased(WorkspaceWasRebased $event): void

--- a/Classes/Projection/EventLogRepository.php
+++ b/Classes/Projection/EventLogRepository.php
@@ -243,7 +243,12 @@ final class EventLogRepository
         } elseif (isset($filterData['workspaceName'])) {
             if ($filterData['includeBaseWorkspaces'] === true) {
                 $queryBuilder = $queryBuilder->andWhere($queryBuilder->expr()->in('contentStreamIdentifier',
-                    'WITH RECURSIVE cte AS (SELECT workSpaceName, baseWorkSpaceName, contentStreamIdentifier FROM ' . self::TABLE_NAME_WORKSPACE . ' WHERE workSpaceName = :workspaceName UNION ALL SELECT w.workSpaceName, w.baseWorkSpaceName, w.contentStreamIdentifier FROM ' . self::TABLE_NAME_WORKSPACE . ' w JOIN cte ON w.workSpaceName = cte.baseWorkSpaceName) SELECT contentStreamIdentifier FROM cte'))->setParameter('workspaceName', $filterData['workspaceName']);
+                    'WITH RECURSIVE cte AS (SELECT workSpaceName, baseWorkSpaceName, contentStreamIdentifier FROM ' . self::TABLE_NAME_WORKSPACE . ' WHERE workSpaceName = :workspaceName UNION ALL SELECT w.workSpaceName, w.baseWorkSpaceName, w.contentStreamIdentifier FROM ' . self::TABLE_NAME_WORKSPACE . ' w JOIN cte ON w.workSpaceName = cte.baseWorkSpaceName) SELECT contentStreamIdentifier FROM cte'))->setParameter('workspaceName',
+                    $filterData['workspaceName']);
+            } elseif ($filterData['includeDerivedWorkspaces'] === true) {
+                $queryBuilder = $queryBuilder->andWhere($queryBuilder->expr()->in('contentStreamIdentifier',
+                    'WITH RECURSIVE cte AS (SELECT workSpaceName, baseWorkSpaceName, contentStreamIdentifier FROM ' . self::TABLE_NAME_WORKSPACE . ' WHERE workSpaceName = :workspaceName UNION ALL SELECT w.workSpaceName, w.baseWorkSpaceName, w.contentStreamIdentifier FROM ' . self::TABLE_NAME_WORKSPACE . ' w JOIN cte ON w.baseWorkSpaceName = cte.workSpaceName) SELECT contentStreamIdentifier FROM cte'))->setParameter('workspaceName',
+                    $filterData['workspaceName']);
             } else {
                 $queryBuilder = $queryBuilder->andWhere($queryBuilder->expr()->eq('contentStreamIdentifier',
                     '(SELECT contentStreamIdentifier FROM ' . self::TABLE_NAME_WORKSPACE . ' WHERE workspaceName = :workspaceName)'))->setParameter('workspaceName', $filterData['workspaceName']);

--- a/Migrations/Mysql/Version20230214181928.php
+++ b/Migrations/Mysql/Version20230214181928.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20230214181928 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add column baseworkspacename to table wwwision_nodeeventlog_projection_workspace';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE `wwwision_nodeeventlog_projection_workspace` ADD baseworkspacename VARCHAR(255) DEFAULT NULL;');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE `wwwision_nodeeventlog_projection_workspace` DROP baseworkspacename');
+    }
+}


### PR DESCRIPTION
Allows to filter events by a workspace including all base or child workspaces

## Usage:

### Include base workspace(s):

```php
$filter = EventLogFilter::create()
    -> inWorkspace($someWorkspaceName, includeBaseWorkspaces: true);
```

### Include child workspace(s):

```php
$filter = EventLogFilter::create()
    -> inWorkspace($someWorkspaceName, includeDerivedWorkspaces: true);
```

**Note:** The flags `includeBaseWorkspaces` and `includeDerivedWorkspaces` must not be used in combination

Resolves: #3